### PR TITLE
Fix off-by-one error in IosSecureRandom when copying bytes

### DIFF
--- a/krypt-core/src/commonMain/kotlin/com.chrynan.krypt.core/SecureString.kt
+++ b/krypt-core/src/commonMain/kotlin/com.chrynan.krypt.core/SecureString.kt
@@ -83,11 +83,11 @@ class SecureString(
     operator fun plus(other: SecureString): SecureString {
         val charArray = CharArray(this.length + other.length)
 
-        for (i in 0..this.length) {
+        for (i in 0 until this.length) {
             charArray[i] = this.chars[i]
         }
 
-        for (i in 0..other.length) {
+        for (i in 0 until other.length) {
             charArray[i + this.length] = other.chars[i]
         }
 

--- a/krypt-csprng/src/commonMain/kotlin/com.chrynan.krypt.csprng/NumberUtils.kt
+++ b/krypt-csprng/src/commonMain/kotlin/com.chrynan.krypt.csprng/NumberUtils.kt
@@ -28,7 +28,7 @@ internal fun ByteArray.toInt(): Int {
     val length = min(4, size)
 
     var value = 0
-    for (i in 0..length) {
+    for (i in 0 until length) {
         val b = this[i]
         value = (value shl 8) + (b and 0xFF.toByte())
     }

--- a/krypt-csprng/src/iosMain/kotlin/com.chrynan.krypt.csprng/IosSecureRandom.kt
+++ b/krypt-csprng/src/iosMain/kotlin/com.chrynan.krypt.csprng/IosSecureRandom.kt
@@ -26,7 +26,7 @@ actual class SecureRandom actual constructor() : Random() {
             if (result == errSecSuccess) {
                 val bytes = ByteArray(length)
 
-                for (i in 0..length) {
+                for (i in 0 until length) {
                     bytes[i] = nativeByteArray[i]
                 }
 

--- a/krypt-csprng/src/iosTest/kotlin/com/chrynan/krypt/csprng/IosSecureRandomTest.kt
+++ b/krypt-csprng/src/iosTest/kotlin/com/chrynan/krypt/csprng/IosSecureRandomTest.kt
@@ -1,0 +1,14 @@
+package com.chrynan.krypt.csprng
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class IosSecureRandomTest {
+    @Test
+    fun `SecureRandom returns a value on iOS`() {
+        val bytes = SecureRandom().nextBytes(32)
+        assertNotNull(bytes)
+        assertEquals(32, bytes.size)
+    }
+}


### PR DESCRIPTION
Fixes #3 